### PR TITLE
Move usage of ugettext to ugettext_lazy

### DIFF
--- a/onfido/admin.py
+++ b/onfido/admin.py
@@ -3,7 +3,7 @@ import simplejson as json  # simplejson supports Decimal
 
 from django.contrib import admin
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .models import (
     Applicant,

--- a/onfido/models.py
+++ b/onfido/models.py
@@ -6,7 +6,7 @@ from dateutil.parser import parse as date_parse
 
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 from .api import get
 from .db.fields import JSONField


### PR DESCRIPTION
According to the [docs](https://docs.djangoproject.com/en/1.8/topics/i18n/translation/#lazy-translations), this is essential in the model & admins files as due to the fact Django creates form fields as class attributes, the translations are loaded at module load time which causes issues during app startup.

Without this, YJ was throwing when importing from the `helpers` module.

>The translation infrastructure cannot be initialized before the django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.