### PR TITLE
Allow helpers.create_applicant to pass through custom data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*.egg-info
+.coverage
+.tox

--- a/onfido/helpers.py
+++ b/onfido/helpers.py
@@ -8,13 +8,23 @@ from .models import (
 )
 
 
-def create_applicant(user):
-    """Create an applicant in the Onfido system."""
+def create_applicant(user, **kwargs):
+    """Create an applicant in the Onfido system.
+
+    Args:
+        user: an auth.User instance to register as an applicant.
+    Kwargs:
+       any kwargs passed in are merged into the data dict sent to the API. This
+       enables support for additional applicant properties - e.g dob, gender,
+       country, and any others that may change over time.
+       See https://documentation.onfido.com/#create-applicant for details.
+    """
     data = {
         "first_name": user.first_name,
         "last_name": user.last_name,
         "email": user.email
     }
+    data.update(kwargs)
     response = post('applicants', data)
     return Applicant.objects.create_applicant(user, response)
 


### PR DESCRIPTION
Before this commit, the helper only had the ability to send first name, last name & email to the [create application endpoint](https://documentation.onfido.com/#create-applicant). This commit allows the user to pass extra data as kwargs, much like the `create_check` helper, which then will get sent directly to the create application endpoint. This allows us to support more than 3 fields now, but also in the future if new fields get added we will be ready to support them.

I've added new tests so that both "providing custom data and not" routes get checked; along with adding some assertions on what exactly `api.post` is called with.


As an aside, this also adds some build/test ephemeral output to the local git ignore, will save future accidents.
