### PR TITLE
Enable functionality with Django's Custom User models

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,9 @@ The main use case is as follows:
 
 .. code:: python
 
-    >>> from django.contrib.auth.models import User
+    >>> from django.contrib.auth import get_user_model
     >>> from onfido.helpers import create_applicant
-    >>> user = User.objects.last()  # any old one will do
+    >>> user = get_user_model().objects.last()  # any old one will do
     >>> applicant = create_applicant(user)
     DEBUG Making POST request to https://api.onfido.com/v2/applicants
     DEBUG <Response [201]>

--- a/onfido/helpers.py
+++ b/onfido/helpers.py
@@ -12,7 +12,7 @@ def create_applicant(user, **kwargs):
     """Create an applicant in the Onfido system.
 
     Args:
-        user: an auth.User instance to register as an applicant.
+        user: a Django User instance to register as an applicant.
     Kwargs:
        any kwargs passed in are merged into the data dict sent to the API. This
        enables support for additional applicant properties - e.g dob, gender,

--- a/onfido/models.py
+++ b/onfido/models.py
@@ -4,7 +4,7 @@ import logging
 
 from dateutil.parser import parse as date_parse
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timezone import now as tz_now
@@ -307,7 +307,7 @@ class Applicant(BaseModel):
     """An Onfido applicant record."""
 
     user = models.OneToOneField(
-        User,
+        settings.AUTH_USER_MODEL,
         help_text=_("Django user that maps to this applicant."),
         related_name='onfido_applicant'
     )
@@ -343,7 +343,7 @@ class Check(BaseStatusModel):
     )
 
     user = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         help_text=_("The Django user (denormalised from Applicant to make navigation easier)."),  # noqa
         related_name='onfido_checks'
     )
@@ -410,7 +410,7 @@ class Report(BaseStatusModel):
     )
 
     user = models.ForeignKey(
-        User,
+        settings.AUTH_USER_MODEL,
         help_text=_("The Django user (denormalised from Applicant to make navigation easier)."),  # noqa
         related_name='onfido_reports'
     )

--- a/onfido/tests/test_admin.py
+++ b/onfido/tests/test_admin.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from decimal import Decimal
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 
@@ -28,7 +28,7 @@ class ResultMixinTests(TestCase):
 
         def request():
             request = mock.Mock()
-            request.user = User()
+            request.user = get_user_model()()
             return request
 
         check = Check()
@@ -83,7 +83,7 @@ class UserMixinTests(TestCase):
 
         def assertUser(first_name, last_name, expected):
             mixin = UserMixin()
-            user = User(first_name=first_name, last_name=last_name)
+            user = get_user_model()(first_name=first_name, last_name=last_name)
             obj = mock.Mock(user=user)
             self.assertEqual(mixin._user(obj), expected)
 

--- a/onfido/tests/test_helpers.py
+++ b/onfido/tests/test_helpers.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from dateutil.parser import parse as date_parse
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from ..helpers import (
@@ -37,7 +37,7 @@ class HelperTests(TestCase):
         """Test the create_applicant function."""
         data = deepcopy(CREATE_APPLICANT_RETURN)
         mock_post.return_value = data
-        user = User.objects.create_user(
+        user = get_user_model().objects.create_user(
             username='fred',
             first_name='Fred',
             last_name='Flintstone',
@@ -61,7 +61,7 @@ class HelperTests(TestCase):
         """Test the create_applicant function with extra custom POST data."""
         data = deepcopy(CREATE_APPLICANT_RETURN)
         mock_post.return_value = data
-        user = User.objects.create_user(
+        user = get_user_model().objects.create_user(
             username='fred',
             first_name='Fred',
             last_name='Flintstone',
@@ -117,7 +117,7 @@ class HelperTests(TestCase):
             ],
         }
         mock_post.return_value = check_data
-        user = User.objects.create_user(
+        user = get_user_model().objects.create_user(
             username='fred',
             first_name='Fred',
             last_name='Flintstone',

--- a/onfido/tests/test_views.py
+++ b/onfido/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase, RequestFactory
 
 from ..compat import mock
@@ -37,7 +37,11 @@ class ViewTests(TestCase):
 
         @mock.patch('onfido.decorators._match', lambda x, y: True)
         def assert_update(data, message):
-            request = factory.post('/', data=json.dumps(data), content_type='application/json')
+            request = factory.post(
+                '/',
+                data=json.dumps(data),
+                content_type='application/json'
+            )
             response = status_update(request)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content.decode('utf-8'), message)
@@ -78,7 +82,7 @@ class ViewTests(TestCase):
 
         # now check that a good payload passes.
         data['payload']['resource_type'] = 'check'
-        user = User.objects.create_user('fred')
+        user = get_user_model().objects.create_user('fred')
         applicant = Applicant(user=user, onfido_id='foo').save()
         check = Check(user=user, applicant=applicant, check_type='standard')
         check.onfido_id = data['payload']['object']['id']


### PR DESCRIPTION
Basically replaces all usage of the hardcoded User model with either settings.AUTH_USER_MODEL (for lazy loading models) or django.contrib.auth.get_user_model (for everything else).

Includes updated docs and test suite.