### PR TITLE
Add data file for supporting countries and util func for whether OnFido supports them

### DIFF
--- a/onfido/data.py
+++ b/onfido/data.py
@@ -4,12 +4,14 @@ import json
 
 
 def get_countries() -> list:
+    """Return a list of countries for consumer parsing."""
     with open("onfido/data/supported_applicant_countries.json") as f:
         countries = json.load(f)
     return countries
 
 
 def check_supported_country(alpha3: str) -> bool:
+    """Check whether a given country is supported by OnFido."""
     with open("onfido/data/supported_applicant_countries.json") as f:
         countries = json.load(f)
 


### PR DESCRIPTION
Using the supported country list from OnFido here: https://documentation.onfido.com/supported-applicant-countries/

I have added two functions which allow the consumer to request the countries from the list `get_countries()`, or determine whether a country is supported `check_supported_country("GBR")`.

This will allow consumers to restrict country selection without needing to hit the API.